### PR TITLE
Fix section parser

### DIFF
--- a/fnl/editorconfig.fnl
+++ b/fnl/editorconfig.fnl
@@ -100,7 +100,7 @@
 
 (fn parse-line [line]
   (when (line:find "^%s*[^ #;]")
-    (match (: (or (line:match "%b[]") "") :match "%[([^%]]+)")
+    (match (: (or (line:match "%b[]") "") :match "^%s*%[(.*)%]%s*$")
       glob (values glob nil nil)
       _ (match (line:match "^%s*([^:= ][^:=]-)%s*[:=]%s*(.-)%s*$")
           (key val) (values nil (key:lower) (val:lower))))))

--- a/lua/editorconfig.lua
+++ b/lua/editorconfig.lua
@@ -88,7 +88,7 @@ local function dirname(path)
 end
 local function parse_line(line)
   if line:find("^%s*[^ #;]") then
-    local _8_ = ((line:match("%b[]") or "")):match("%[([^%]]+)")
+    local _8_ = ((line:match("%b[]") or "")):match("^%s*%[(.*)%]%s*$")
     if (nil ~= _8_) then
       local glob = _8_
       return glob, nil, nil


### PR DESCRIPTION
Handle cases where section globs contain a closing square bracket.

For example:

[*.{yaml,yml,[Yy][Mm][Ll],[Yy][Aa][Mm][Ll]}]