### PR TITLE
Add Trigger User autocmd after config

### DIFF
--- a/fnl/editorconfig.fnl
+++ b/fnl/editorconfig.fnl
@@ -148,7 +148,8 @@
                    (false err) (let [msg (: "editorconfig: invalid value for option %s: %s. %s" :format opt val err)]
                                  ; 'title' is supported by nvim-notify
                                  (vim.notify msg vim.log.levels.WARN {:title "editorconfig"}))))))
-      (tset vim.b bufnr :editorconfig applied))))
+      (tset vim.b bufnr :editorconfig applied)
+      (vim.api.nvim_exec_autocmds :User {:pattern :EditorConfigPost}))))
 
 (fn trim_trailing_whitespace []
   (let [view (vim.fn.winsaveview)]

--- a/lua/editorconfig.lua
+++ b/lua/editorconfig.lua
@@ -203,7 +203,7 @@ local function config(bufnr)
       end
     end
     vim.b[bufnr0]["editorconfig"] = applied
-    return nil
+    return vim.api.nvim_exec_autocmds("User", {pattern = "EditorConfigPost"})
   else
     return nil
   end


### PR DESCRIPTION
I just add user autocmd `EditorConfigPost` to make auto detect indent base on `vim.b` after editorconfig.