### PR TITLE
Use :undojoin before trimming whitespace

### DIFF
--- a/fnl/editorconfig.fnl
+++ b/fnl/editorconfig.fnl
@@ -30,6 +30,7 @@
 ; TODO: Inline this function when trim_trailing_whitespace is removed
 (fn trim-trailing-whitespace []
   (let [view (vim.fn.winsaveview)]
+    (vim.api.nvim_command "silent! undojoin")
     (vim.api.nvim_command "silent keepjumps keeppatterns %s/\\s\\+$//e")
     (vim.fn.winrestview view)))
 

--- a/lua/editorconfig.lua
+++ b/lua/editorconfig.lua
@@ -8,6 +8,7 @@ local function warn(msg)
 end
 local function trim_trailing_whitespace()
   local view = vim.fn.winsaveview()
+  vim.api.nvim_command("silent! undojoin")
   vim.api.nvim_command("silent keepjumps keeppatterns %s/\\s\\+$//e")
   return vim.fn.winrestview(view)
 end


### PR DESCRIPTION
Fixes: https://github.com/gpanders/editorconfig.nvim/issues/26
